### PR TITLE
Fix response_lock in userreturn controller

### DIFF
--- a/controllers/front/userreturn.php
+++ b/controllers/front/userreturn.php
@@ -34,7 +34,6 @@ class TggAtosUserReturnModuleFrontController extends TggAtosModuleFrontControlle
 		$id_cart = (int)$response->order_id;
 		$lock = uniqid('', true);
 		$has_lock = $this->module->tryCreateResponseLock($id_cart, $lock);
-		$has_lock = false;
 		$can_proceed = null;
 		if (!$has_lock) {
 			$can_proceed = $this->module->waitForLockRemoval($id_cart);

--- a/tggatos.php
+++ b/tggatos.php
@@ -1126,7 +1126,7 @@ class TggAtos extends PaymentModule
 		$DB->execute('
 			DELETE FROM `'.$this->getTable(self::TABLE_RESPONSE_LOCK).'`
 			WHERE
-				`id_cart` = '.(int)$id_cart.',
+				`id_cart` = '.(int)$id_cart.' AND
 				`lock` = \''.pSQL($lock).'\'
 			;
 		', false);


### PR DESCRIPTION
Response lock doesn't work in TggAtosUserReturnModuleFrontController.
$has_lock is always false.

There also a small sql errror in tggatos.php (Tested with mysql 5.6.28)
